### PR TITLE
Update new-duoRequest.ps1

### DIFF
--- a/scripts/new-duoRequest.ps1
+++ b/scripts/new-duoRequest.ps1
@@ -89,7 +89,7 @@ function New-duoRequest(){
         URI         = ('https://{0}{1}' -f $apiHost, $apiEndpoint)
         Headers     = @{
             "X-Duo-Date"    = $Date
-            "Authorization" = "Basic: $authHeader"
+            "Authorization" = "Basic $authHeader"
         }
         Body = $requestParams
         Method      = $requestMethod


### PR DESCRIPTION
The original code fails with Auth error: The format of value 'Basic: <key removed>' is invalid. Looking at the API documentation, it shows that Basic should have a colon after it. Have remove the colon in my code and it works now
Line 92: